### PR TITLE
Add LICENSE to source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+LICENSE


### PR DESCRIPTION
Thanks for roundrobin!

This PR ensures the LICENSES is included in the `.tar.gz`, which is useful for downstream packaging systems that require it (even if the terms of the license don't).

Thanks again!